### PR TITLE
Add More Exclusionary Rules to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,35 @@ bin-release/
 *.ipa
 *.apk
 
+# OS Specific Files
+# Mac
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# File that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.


### PR DESCRIPTION
This PR updates the .gitignore file with more system entries.  The new exclusion rules are for garbage files on MacOS/Windows that we don't want to track as part of our git repo.  This includes things like thumbnail files, document icons, and temporary / trash items.